### PR TITLE
Add EduVideoBot demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+scenes/
+narration.wav
+output.mp4

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
-# TTV
-TTV APP
+# EduVideoBot
+
+This repository contains a minimal example of generating a narrated slideshow
+video from a text prompt. Images are generated using Pillow with the scene text,
+audio narration is produced with `pyttsx3`, and the final video is assembled
+with `moviepy`.
+
+## Requirements
+
+- Python 3.8+
+- [ffmpeg](https://ffmpeg.org/) (for video rendering)
+- A TTS engine supported by `pyttsx3` (e.g. `espeak` on Linux)
+
+Install Python dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+python edu_video_bot.py "Explain photosynthesis with a happy tree and sun shining down"
+```
+
+This will create placeholder images, generate narration from the text, and
+produce `output.mp4` in the current directory.

--- a/edu_video_bot.py
+++ b/edu_video_bot.py
@@ -1,0 +1,76 @@
+import os
+import argparse
+from PIL import Image, ImageDraw, ImageFont
+import pyttsx3
+from moviepy.editor import ImageClip, concatenate_videoclips, AudioFileClip
+
+
+def text_to_scenes(text):
+    """Split text into scenes using periods."""
+    scenes = [s.strip() for s in text.split('.') if s.strip()]
+    return scenes
+
+
+def generate_image(text, index, out_dir="scenes"):
+    os.makedirs(out_dir, exist_ok=True)
+    img = Image.new('RGB', (640, 480), color=(255, 255, 255))
+    draw = ImageDraw.Draw(img)
+    font = ImageFont.load_default()
+    # Wrap text if necessary
+    lines = []
+    words = text.split()
+    line = ''
+    for word in words:
+        if draw.textsize(line + ' ' + word, font=font)[0] < 600:
+            line += ' ' + word
+        else:
+            lines.append(line.strip())
+            line = word
+    lines.append(line.strip())
+    y = 200
+    for line in lines:
+        w, h = draw.textsize(line, font=font)
+        draw.text(((640 - w) / 2, y), line, fill=(0, 0, 0), font=font)
+        y += h + 5
+    path = os.path.join(out_dir, f"scene_{index:03d}.png")
+    img.save(path)
+    return path
+
+
+def generate_images(scenes):
+    paths = []
+    for i, scene in enumerate(scenes):
+        paths.append(generate_image(scene, i))
+    return paths
+
+
+def generate_narration(text, out_file="narration.wav"):
+    engine = pyttsx3.init()
+    engine.save_to_file(text, out_file)
+    engine.runAndWait()
+    return out_file
+
+
+def create_video(image_paths, audio_path, out_file="output.mp4", duration_per_image=3):
+    clips = [ImageClip(p).set_duration(duration_per_image) for p in image_paths]
+    video = concatenate_videoclips(clips, method="compose")
+    if audio_path:
+        narration = AudioFileClip(audio_path)
+        video = video.set_audio(narration)
+    video.write_videofile(out_file, fps=24)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="EduVideoBot simple demo")
+    parser.add_argument("text", help="Input description text")
+    parser.add_argument("--output", default="output.mp4", help="Output video file")
+    args = parser.parse_args()
+
+    scenes = text_to_scenes(args.text)
+    image_paths = generate_images(scenes)
+    audio_path = generate_narration(args.text)
+    create_video(image_paths, audio_path, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Pillow
+pyttsx3
+moviepy


### PR DESCRIPTION
## Summary
- add `edu_video_bot.py` with placeholder implementation for generating narrated slideshow videos
- provide setup instructions in `README.md`
- add `requirements.txt` and `.gitignore`

## Testing
- `python -m py_compile edu_video_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6852708d961c83338d03b800fb34aecf